### PR TITLE
added final catch() after call to perform() in analyze_MPMD.

### DIFF
--- a/src/Analyze_MPMD.cpp
+++ b/src/Analyze_MPMD.cpp
@@ -56,7 +56,14 @@ int main(int aArgc, char **aArgv)
       safeExit(tErrorCode);
     }
 
-    tPlatoInterface->perform();
+    try
+    {
+      tPlatoInterface->perform();
+    }
+    catch(...)
+    {
+      safeExit();
+    }
 
     if(tMyApp)
     {


### PR DESCRIPTION
analyze_MPMD now exits without writing the stack to the console in the event of a signal.  Previously, caught errors where written to the console followed by the stack.