### PR TITLE
skipping state update for linear criteria

### DIFF
--- a/src/Analyze_App.cpp
+++ b/src/Analyze_App.cpp
@@ -679,7 +679,10 @@ void MPMD_App::ComputeCriterion::operator()()
     auto& tValue  = mMyApp->mCriterionValues[mStrCriterion];
     auto& tGradZ  = mMyApp->mCriterionGradientsZ[mStrCriterion];
 
-    mMyApp->mGlobalSolution = mMyApp->mProblem->solution(tControl);
+    if ( mMyApp->mProblem->criterionIsLinear(mStrCriterion) == false )
+    {
+        mMyApp->mGlobalSolution = mMyApp->mProblem->solution(tControl);
+    }
 
     tValue = mMyApp->mProblem->criterionValue(tControl, tState, mStrCriterion);
     tValue -= mTarget;
@@ -737,7 +740,10 @@ void MPMD_App::ComputeCriterionX::operator()()
     auto& tValue  = mMyApp->mCriterionValues[mStrCriterion];
     auto& tGradX  = mMyApp->mCriterionGradientsX[mStrCriterion];
 
-    tState = mMyApp->mProblem->solution(tControl);
+    if ( mMyApp->mProblem->criterionIsLinear(mStrCriterion) == false )
+    {
+        tState = mMyApp->mProblem->solution(tControl);
+    }
     tValue = mMyApp->mProblem->criterionValue(tControl, tState, mStrCriterion);
     tValue -= mTarget;
     tGradX = mMyApp->mProblem->criterionGradientX(tControl, tState, mStrCriterion);
@@ -846,7 +852,10 @@ void MPMD_App::ComputeCriterionValue::operator()()
     auto& tState   = mMyApp->mGlobalSolution;
     auto& tValue  = mMyApp->mCriterionValues[mStrCriterion];
 
-    tState = mMyApp->mProblem->solution(tControl);
+    if ( mMyApp->mProblem->criterionIsLinear(mStrCriterion) == false )
+    {
+        tState = mMyApp->mProblem->solution(tControl);
+    }
     tValue = mMyApp->mProblem->criterionValue(tControl, tState, mStrCriterion);
     tValue -= mTarget;
 

--- a/src/PlatoAbstractProblem.hpp
+++ b/src/PlatoAbstractProblem.hpp
@@ -111,6 +111,15 @@ public:
     )=0;
 
     /******************************************************************************//**
+     * \brief Is criterion independent of the solution state?
+     * \param [in] aName Name of criterion.
+    **********************************************************************************/
+    virtual bool
+    criterionIsLinear(
+        const std::string & aName
+    ){ return false; }
+
+    /******************************************************************************//**
      * \brief Evaluate criterion function
      * \param [in] aControl 1D view of control variables
      * \param [in] aName Name of criterion.

--- a/src/elliptic/Problem.hpp
+++ b/src/elliptic/Problem.hpp
@@ -152,6 +152,18 @@ public:
     }
 
     /******************************************************************************//**
+     * \brief Is criterion independent of the solution state?
+     * \param [in] aName Name of criterion.
+    **********************************************************************************/
+    bool
+    criterionIsLinear(
+        const std::string & aName
+    ) override
+    {
+        return mLinearCriteria.count(aName) > 0 ? true : false;
+    }
+
+    /******************************************************************************//**
      * \brief Return number of degrees of freedom in solution.
      * \return Number of degrees of freedom
     **********************************************************************************/

--- a/src/parabolic/Problem.hpp
+++ b/src/parabolic/Problem.hpp
@@ -191,6 +191,19 @@ namespace Parabolic
             mSolver = tSolverFactory.create(aMesh, aMachine, SimplexPhysics::mNumDofsPerNode);
 
         }
+
+        /******************************************************************************//**
+         * \brief Is criterion independent of the solution state?
+         * \param [in] aName Name of criterion.
+        **********************************************************************************/
+        bool
+        criterionIsLinear(
+            const std::string & aName
+        ) override
+        {
+            return mLinearCriteria.count(aName) > 0 ? true : false;
+        }
+
         /******************************************************************************//**
          * @brief Return number of degrees of freedom in solution.
          * @return Number of degrees of freedom


### PR DESCRIPTION
Linear criteria were needlessly recomputing the solution state leading to an unnecessary solve. 