### PR TITLE
adds ifdef for whether we build with 13.0.1 or rol branch of trilinos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,10 @@ ELSE()
   MESSAGE(FATAL_ERROR "Cannot locate the executable for vtkdiff, exiting")
 ENDIF()
 
+IF( TRILINOS_ROL_BRANCH )
+  ADD_DEFINITIONS(-DTRILINOS_ROL_BRANCH)
+ENDIF()
+
 # DAI: omega_h2 has a vtkdiff which by default compares all timesteps.
 # old omega_h's vtkdiff only compared one timestep.
 # at the time of transition, we will keep comparing just one time step

--- a/src/PlatoMathHelpers.hpp
+++ b/src/PlatoMathHelpers.hpp
@@ -616,8 +616,11 @@ MatrixMinusMatrix(      Teuchos::RCP<Plato::CrsMatrixType> & aInMatrixOne,
       tOutRowMap
     );
 
-    // auto t_nnz = tAddHandle->get_c_nnz();
+#ifdef TRILINOS_ROL_BRANCH
+    auto t_nnz = tAddHandle->get_c_nnz();
+#else
     auto t_nnz = tAddHandle->get_max_result_nnz();
+#endif
 
     OrdinalView tOutColMap("output graph", t_nnz);
     ScalarView  tOutValues("output values", t_nnz);


### PR DESCRIPTION
This change goes hand in hand with a chance I made in spack.  I pushed the change to spack but forgot to push this one.  Basically, we need a different function call depending on whether we build with Trilinos 13.0.1 or the develop branch of Trilinos (right now we're forced to build off a specific commit of the develop branch when building PE with +rol or +prune)