### PR TITLE
deprecated method call and added new method from engine changes

### DIFF
--- a/src/Analyze_App.hpp
+++ b/src/Analyze_App.hpp
@@ -137,6 +137,11 @@ public:
     **********************************************************************************/
     void initialize();
 
+     /******************************************************************************//**
+     * \brief reinitialize
+    **********************************************************************************/
+    void reinitialize() {};
+
     /******************************************************************************//**
      * \brief Compute this operation
      * \param [in] aOperationName operation name
@@ -212,7 +217,7 @@ public:
         else if(aName == "Solution")
         {
             auto tTags = mGlobalSolution.tags();
-	    auto tState = mGlobalSolution.get(tTags[0]);
+            auto tState = mGlobalSolution.get(tTags[0]);
             const Plato::OrdinalType tTIME_STEP_INDEX = 0;
             auto tStatesSubView = Kokkos::subview(tState, tTIME_STEP_INDEX, Kokkos::ALL());
             this->copyFieldIntoAnalyze(tStatesSubView, aSharedField);
@@ -495,7 +500,7 @@ private:
     /******************************************************************************//**
      * \fn resetProblemMetaData
      * \brief Reset Analyze problem metadata. Metadata includes state, control, and \n
-     * respective gradients.  
+     * respective gradients.
     **********************************************************************************/
     void resetProblemMetaData();
 
@@ -826,7 +831,7 @@ private:
     /******************************************************************************/
     class ReloadMesh : public LocalOp
     {
-    public:	
+    public:
         ReloadMesh(MPMD_App* aMyApp, Plato::InputData& aNode, Teuchos::RCP<ProblemDefinition> aOpDef);
         void operator()();
     private:
@@ -853,14 +858,14 @@ private:
 
     /******************************************************************************//**
      * \class Visualization
-     * \brief Plato Analyze operation used to visualize output field data at each 
-     *        optimization iteration. This operation avoids having to send large 
-     *        field data sets through Plato Engine. 
-     * 
-     *        The output history is saved inside the 'plato_analyze_output' 
-     *        directory. One can have access to the output information for each 
-     *        optimization iteration (e.g. 'plato_analyze_output/iteration#', 
-     *        where # denotes the optimization itertion) or for the full 
+     * \brief Plato Analyze operation used to visualize output field data at each
+     *        optimization iteration. This operation avoids having to send large
+     *        field data sets through Plato Engine.
+     *
+     *        The output history is saved inside the 'plato_analyze_output'
+     *        directory. One can have access to the output information for each
+     *        optimization iteration (e.g. 'plato_analyze_output/iteration#',
+     *        where # denotes the optimization itertion) or for the full
      *        optimization run (e.g. 'plato_analyze_output/history.pvd')
     **********************************************************************************/
     class Visualization : public LocalOp

--- a/src/Analyze_MPMD.cpp
+++ b/src/Analyze_MPMD.cpp
@@ -65,7 +65,7 @@ int main(int aArgc, char **aArgv)
 
     try
     {
-      tPlatoInterface->registerPerformer(tMyApp);
+      tPlatoInterface->registerApplication(tMyApp);
     }
     catch(...)
     {


### PR DESCRIPTION
@jrobbin and @rviertel 

These are two very minor changes needed on the Analyze side to support the nested optimization on the engine side. However, they are a no-op against the current develop Engine. As such, they can go into the develop branch now without any impact. That will make it easier for building the Nested_Opt Engine and running the ShapeTopo test as you will not need a separate build of the Analyze code.

BTW As matter of habit I always do an untabify and delete trailing whitespace. So if you do a git diff add "-w" you will see the two changes.