### PR TITLE
Previously, analyze would crash on AD operations if built for the CPU…

### DIFF
--- a/src/Simp.hpp
+++ b/src/Simp.hpp
@@ -129,7 +129,7 @@ public:
     template<typename ScalarType>
     KOKKOS_INLINE_FUNCTION ScalarType operator()( const ScalarType & aInput ) const
     {
-        auto tOutput = mMinValue + ( (static_cast<ScalarType>(1.0) - mMinValue) * pow(aInput, mPenaltyParam) );
+        ScalarType tOutput = mMinValue + ( (static_cast<ScalarType>(1.0) - mMinValue) * pow(aInput, mPenaltyParam) );
         return tOutput;
     }
 };


### PR DESCRIPTION
… without doing a debug build or setting target=x86_64

This commit fixes the issue for Analyze_CompMin3D_ROL_LC. There may be other instances of the same problem that we'll find by running all the tests on the CPU.

Christian says this is a classic issue: a dangling reference to an expression template. Using auto has it return an expression template, which then has to be converted to a scalar type in the return statement, by which time it has gone out of scope with the optimizations going on.