### PR TITLE
TO-4950: Disable hatching gradients

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,9 @@ option(CUSTOMMATERIALS "Compile with custom materials"       OFF)
 option(HATCHING        "Compile with hatching algorithm"     ON )
 option(MICROMORPHIC    "Compile with Micromorphic physics"   ON )
 
+# Experimental option for using shape optimization with inherent strain/hatching
+option(HATCHING_GRADIENT "Compile with hatching gradients, enabling shape optimization with elliptic hatching problem" OFF)
+
 option(HEX_ELEMENTS    "Compile with hex*, quad* elements"   OFF )
 option(ALL_PENALTY     "Compile with Ramp and Heaviside"     OFF )
 
@@ -236,6 +239,10 @@ endif()
 if(HATCHING)
   message("-- Plato: Hatching algorithm added")
   ADD_DEFINITIONS(-DPLATO_HATCHING)
+endif()
+if(HATCHING_GRADIENT)
+  message("-- Plato: Experimental hatching gradients enabled.")
+  ADD_DEFINITIONS(-DPLATO_HATCHING_GRADIENTS)
 endif()
 if(HYPERBOLIC)
   message("-- Plato: Hyperbolic physics added")

--- a/src/PlatoPythonModule.cpp
+++ b/src/PlatoPythonModule.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <sstream>
 #include <iostream>
+#include <stdexcept>
 #include <Analyze_App.hpp>
 
 std::vector<Plato::Scalar> double_vector_from_list(PyObject* list);
@@ -182,8 +183,21 @@ Analyze_compute(Analyze *self, PyObject *args, PyObject *kwds)
     std::cout << "Computing " << operationName << std::endl;
 
     std::string opName(operationName);
-    self->mMPMDApp->compute(opName);
-
+    try
+    {
+        self->mMPMDApp->compute(opName);
+    } 
+    catch(const std::runtime_error& err) 
+    {
+        // Expected exception type from ANALYZE_THROWERR
+        PyErr_SetString(PyExc_RuntimeError, err.what());
+        return NULL;
+    }
+    catch(...)
+    {
+        PyErr_SetString(PyExc_RuntimeError, "Unexpected C++ exception.");
+        return NULL;
+    }
     return Py_BuildValue("i", 1);
 }
 

--- a/src/elliptic/hatching/Problem_def.hpp
+++ b/src/elliptic/hatching/Problem_def.hpp
@@ -22,6 +22,10 @@ namespace Elliptic
 
 namespace Hatching
 {
+namespace
+{
+    constexpr auto kHatchingGradientDisabledErrorMessage = "Hatching gradients are disabled. The HATCHING_GRADIENT build option must be enabled to use this feature.";
+}
 
     /******************************************************************************//**
      * \brief PLATO problem constructor
@@ -510,6 +514,10 @@ namespace Hatching
         const std::string         & aName
     )
     {
+#ifndef PLATO_HATCHING_GRADIENTS
+        ANALYZE_THROWERR(kHatchingGradientDisabledErrorMessage);
+#endif
+
         if( mCriteria.count(aName) )
         {
             Criterion tCriterion = mCriteria[aName];
@@ -543,6 +551,11 @@ namespace Hatching
         const Plato::Solutions    & aSolution,
               Criterion             aCriterion)
     {
+
+#ifndef PLATO_HATCHING_GRADIENTS
+        ANALYZE_THROWERR(kHatchingGradientDisabledErrorMessage);
+#endif
+
         if(aCriterion == nullptr)
         {
             ANALYZE_THROWERR("REQUESTED CRITERION NOT DEFINED BY USER.");


### PR DESCRIPTION
Adds a CMake variable to disable hatching gradient calculations. Throws an error when disabled. Also, adds exception handing in the python interface for use with the regression test in platoengine.