### PR TITLE
TO-5145 Adds boost serialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,8 @@ set(CMAKE_CXX_COMPILER ${Trilinos_CXX_COMPILER})
 set(CMAKE_C_COMPILER ${Trilinos_C_COMPILER})
 set(CMAKE_Fortran_COMPILER ${Trilinos_Fortran_COMPILER})
 
+find_package(Boost REQUIRED COMPONENTS serialization)
+
 set(THREAD_COUNT "" CACHE STRING "Default number of threads to use")
 if(THREAD_COUNT)
   set(ALL_THREAD_ARGS "--kokkos-threads=${THREAD_COUNT}")
@@ -414,7 +416,8 @@ if (PLATOANALYZE_ENABLE_MPMD)
   endif()
 
   target_link_libraries(Analyze_App ${PLATO_LIBS} ${PLATO_LIBS} analyzelib)
-  target_link_libraries(analyze_MPMD Analyze_App ${PLATO_LIBS} ${PLATO_LIBS} analyzelib)
+  target_link_libraries(analyze_MPMD Analyze_App ${PLATO_LIBS} ${PLATO_LIBS} analyzelib Boost::serialization)
+  target_compile_definitions(analyze_MPMD PRIVATE BOOST_NO_AUTO_PTR=1) # Suppress warnings on nvcc build
 
   if (PLATOANALYZE_ENABLE_PYTHON)
       find_package(Python3 COMPONENTS Development)
@@ -424,6 +427,7 @@ if (PLATOANALYZE_ENABLE_MPMD)
       target_include_directories( PlatoPython PRIVATE "${PLATOENGINE_PREFIX}/include")
       target_include_directories( PlatoPython PRIVATE ${Trilinos_INCLUDE_DIRS} ${Trilinos_TPL_INCLUDE_DIRS})
       target_link_libraries( PlatoPython Analyze_App analyzelib ${PLATO_LIBS} ${Trilinos_LIBRARIES} ${Trilinos_TPL_LIBRARIES} ${Python3_LIBRARIES} )
+      target_compile_definitions( PlatoPython PRIVATE BOOST_NO_AUTO_PTR=1) # Suppress warnings on nvcc build
       set_target_properties( PlatoPython PROPERTIES PREFIX "" )
       target_compile_options( PlatoPython PRIVATE "-lmpi" )
       if( CMAKE_INSTALL_PREFIX )

--- a/src/Analyze_App.hpp
+++ b/src/Analyze_App.hpp
@@ -6,10 +6,10 @@
 #include <iostream>
 #include <math.h>
 
+#include <Plato_Console.hpp>
 #include <Plato_InputData.hpp>
 #include <Plato_Application.hpp>
 #include <Plato_Exceptions.hpp>
-#include <Plato_Interface.hpp>
 #include <Plato_PenaltyModel.hpp>
 #include <Plato_SharedData.hpp>
 #include <Plato_SharedField.hpp>

--- a/src/Analyze_MPMD.cpp
+++ b/src/Analyze_MPMD.cpp
@@ -1,4 +1,5 @@
 #include "Analyze_App.hpp"
+#include "Plato_Interface.hpp"
 #include <Teuchos_Comm.hpp>
 #include <Teuchos_DefaultMpiComm.hpp>
 #include <Teuchos_TimeMonitor.hpp>

--- a/src/elliptic/VolAvgStressPNormDenominator_def.hpp
+++ b/src/elliptic/VolAvgStressPNormDenominator_def.hpp
@@ -57,8 +57,6 @@ namespace Elliptic
 
       auto tNumCells = mSpatialDomain.numCells();
 
-      Plato::ComputeGradientMatrix<ElementType> tComputeGradient;
-
       Plato::ScalarVectorT<ConfigScalarType> tCellVolume("cell weight", tNumCells);
 
       Plato::ScalarMultiVectorT<ResultScalarType> tCellWeights("weighted one", tNumCells, mNumVoigtTerms);

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -102,6 +102,7 @@ if(PLATOANALYZE_ENABLE_MPMD)
   target_include_directories(AnalyzeAppIntxTests PRIVATE "${CMAKE_SOURCE_DIR}/src")
   target_include_directories(AnalyzeAppIntxTests PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/BamG")
   target_include_directories(AnalyzeAppIntxTests PRIVATE ${Trilinos_INCLUDE_DIRS} ${Trilinos_TPL_INCLUDE_DIRS})
+  target_compile_definitions(AnalyzeAppIntxTests PRIVATE BOOST_NO_AUTO_PTR=1) # Suppress warnings on nvcc build
 
   if (PLATOANALYZE_ENABLE_ENGINEMESH)
     set(EngineMesh_SOURCES
@@ -147,6 +148,7 @@ if(PLATOANALYZE_ENABLE_MPMD)
     target_include_directories(MeshMapUnitTests PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/BamG")
     target_include_directories(MeshMapUnitTests PRIVATE ${Trilinos_INCLUDE_DIRS} ${Trilinos_TPL_INCLUDE_DIRS})
     target_link_libraries(MeshMapUnitTests ArborX::ArborX BamGlib)
+    target_compile_definitions(MeshMapUnitTests PRIVATE BOOST_NO_AUTO_PTR=1) # Suppress warnings on nvcc build
 
     build_mpi_test_string(ES_MPI_TEST 1 ${CMAKE_CURRENT_BINARY_DIR}/MeshMapUnitTests)
     add_test(NAME runMeshMapUnitTests COMMAND ${ES_MPI_TEST})

--- a/unit_tests/PlatoSolverInterfaceTests.cpp
+++ b/unit_tests/PlatoSolverInterfaceTests.cpp
@@ -1451,7 +1451,7 @@ TEUCHOS_UNIT_TEST( SolverInterfaceTests, AmgXElastic2D )
     //
     constexpr auto tAmgxSolverParameters = 
       "<ParameterList name='Linear Solver'>                                     \n"
-      "  <Parameter name='Solver' type='string' value='AmgX'/>                  \n"
+      "  <Parameter name='Solver Stack' type='string' value='AmgX'/>            \n"
       "  <Parameter name='Configuration File' type='string' value='amgx.json'/> \n"
       "</ParameterList>                                                         \n";
     constexpr double tRelativeTol = 1e-12;


### PR DESCRIPTION
Adds boost serialization linking to PA and some compiler definitions to clear warnings on nvcc related to boost.

Merge w/ https://github.com/platoengine/platoengine/pull/407