### PR TITLE
Adds setting of target solution value

### DIFF
--- a/src/elliptic/SolutionFunction_def.hpp
+++ b/src/elliptic/SolutionFunction_def.hpp
@@ -139,6 +139,7 @@ namespace Elliptic
                 break; 
             case solution_type_t::DIFF_BETWEEN_SOLUTION_IN_DIRECTION_AND_TARGET_SOLUTION_IN_DIRECTION:
                 {
+                    mTargetSolution = tFunctionParams.get<Plato::Scalar>("TargetSolution");
                     initialize_normal_vector(tFunctionParams);
                     auto tNormal = mNormal;
                     auto tTargetSolution = mTargetSolution;


### PR DESCRIPTION
Previously, target solution value wasn't set leaving it uninitialized. Tests would pass if it was initialized to 0.

While updating spack the test GC_Analyze_Disp_TargetSolution was failing and I found that the target solution value was uninitialized. This fixes the issue for me.